### PR TITLE
chore: add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 erasmusevec-bot
+Copyright (c) 2025 Blagoj Ristov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- add MIT License for 2025

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a3b5cc0a988327bc11b9e6e17bcb52