### PR TITLE
docs: add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+We are currently in active development. Only the latest version of the project is supported.
+
+| Version | Supported |
+| ------- | --------- |
+| main    | ✅        |
+
+---
+
+## Reporting a Vulnerability
+If you discover a security vulnerability in this project, please report it responsibly.
+
+### How to Report
+- Send an email to **blagoj@evec.org.gr** with a detailed description of the issue.
+- Include steps to reproduce the vulnerability if possible.
+- Do not publicly disclose the vulnerability until it has been addressed.
+
+### What to Expect
+- You will receive an acknowledgement within **72 hours**.
+- We will provide regular updates on the status of the fix.
+- Once the vulnerability is resolved, we will notify you before making it public.
+
+---
+
+## Responsible Disclosure
+We kindly ask that you:
+- Do not exploit vulnerabilities beyond what is necessary to demonstrate them.
+- Do not publicly share details until an official fix has been released.
+- Act in good faith and help us improve the security of this project.
+
+---
+
+Thank you for helping us keep **Seller-Assistant** safe and secure!


### PR DESCRIPTION
## Summary
- add security policy detailing supported versions and vulnerability reporting guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3b67b4ff08327999312d633798752