### PR TITLE
docs: add system architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,88 @@
+# Seller-Assistant – System Architecture  
+
+This document describes the planned technical architecture of **Seller-Assistant**. It helps contributors and developers understand how the system is structured and how components interact.  
+
+---
+
+## 🏗️ High-Level Overview
+Seller-Assistant will be developed as a **mobile-first web application** with optional native wrappers for iOS/Android.  
+Key components include:  
+- **Frontend (Mobile/Web UI)**  
+- **Backend API (Business Logic & Authentication)**  
+- **Database (Persistent Storage)**  
+- **Integrations (3rd party services, payments, analytics)**  
+
+---
+
+## 📱 Frontend
+- **Framework**: React Native (for mobile apps) and React.js/Next.js (for web).  
+- **UI Toolkit**: TailwindCSS + shadcn/ui for fast, consistent design.  
+- **Responsibilities**:  
+  - User onboarding & authentication  
+  - Dashboard for sales agents  
+  - Marketplace interface (browse, order, track)  
+  - Training modules (micro-courses, video, quizzes)  
+  - Notifications & reminders  
+
+---
+
+## ⚙️ Backend (API & Logic)
+- **Framework**: Node.js with Express.js or NestJS  
+- **Authentication**: JWT + OAuth2 (Google/Facebook login optional)  
+- **Responsibilities**:  
+  - User & role management (agents, producers, cooks, store employees)  
+  - Commission tracking & payouts  
+  - Product catalog management (microgreens, other local products)  
+  - Order processing & payment handling  
+  - Analytics (sales, performance dashboards)  
+  - Training content delivery  
+
+---
+
+## 🗄️ Database
+- **Primary Database**: PostgreSQL (scalable relational database).  
+- **Optional Search Layer**: ElasticSearch (for product and customer search).  
+- **Schema Overview**:  
+  - `Users` (agents, producers, cooks, store employees, admins)  
+  - `Products` (microgreens, vegetables, herbs, etc.)  
+  - `Orders` (status, payments, commissions)  
+  - `TrainingModules` (lessons, quizzes, progress tracking)  
+  - `Analytics` (KPIs, sales performance, growth metrics)  
+
+---
+
+## 🌍 Integrations
+- **Payments**: Stripe / PayPal for global, Viva Wallet for EU.  
+- **Notifications**: Firebase Cloud Messaging (push) + email (SendGrid).  
+- **Analytics**: Mixpanel or Google Analytics for usage metrics.  
+- **Geolocation**: Google Maps API for store/producer proximity.  
+
+---
+
+## 🔐 Security
+- Role-based access control (RBAC).  
+- Encrypted connections (HTTPS/TLS).  
+- Secure storage of sensitive data (hashed passwords, no plain-text secrets).  
+- Regular audits following the SECURITY.md guidelines.  
+
+---
+
+## 🚀 Deployment
+- **Hosting**:  
+  - Frontend: Vercel / Netlify  
+  - Backend: AWS / DigitalOcean / Heroku  
+  - Database: AWS RDS / Supabase  
+- **CI/CD**: GitHub Actions for automated testing, builds, and deployments.  
+
+---
+
+## 🔄 Scalability Plan
+- Year 1–2: Monolithic backend (simpler, cheaper).  
+- Year 3–5: Transition to microservices (scalable per feature).  
+- Use containerization (Docker + Kubernetes) for production scaling.  
+
+---
+
+## 📌 Summary
+The architecture balances **simplicity** (easy for small teams) with **scalability** (ready for growth in 5+ years). It allows Seller-Assistant to start lean (grant-funded MVP) and expand into a global SaaS platform.  
+


### PR DESCRIPTION
## Summary
- add an architecture overview outlining frontend, backend, database, integrations, security, deployment, and scalability plans

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b713d2f0832796b3bc42667feaa9