### PR TITLE
ci: add basic CI (typecheck, lint, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs typecheck, lint, and build on Node 18

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Seller-Assistant/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a3bee54dd08327a40b74bd483b9903