### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies (lockfile exact)
+        run: npm ci
+
+      # TEMP FIX: if @supabase/supabase-js isn't in package.json/lockfile yet,
+      # install it just for CI so typecheck doesn't fail.
+      - name: Ensure CI-only deps
+        run: |
+          if ! node -e "process.exit(require('./package.json').dependencies?.['@supabase/supabase-js'] ? 0 : 1)"; then
+            echo "Installing @supabase/supabase-js for CI only..."
+            npm install @supabase/supabase-js --no-save
+          fi
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     branches: [main]
@@ -9,34 +8,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm
+          cache: 'npm'
 
-      - name: Install dependencies (lockfile exact)
-        run: npm ci
+      - run: npm ci
 
-      # TEMP FIX: if @supabase/supabase-js isn't in package.json/lockfile yet,
-      # install it just for CI so typecheck doesn't fail.
-      - name: Ensure CI-only deps
-        run: |
-          if ! node -e "process.exit(require('./package.json').dependencies?.['@supabase/supabase-js'] ? 0 : 1)"; then
-            echo "Installing @supabase/supabase-js for CI only..."
-            npm install @supabase/supabase-js --no-save
-          fi
+      # If your project has type-check script (tsc --noEmit)
+      - run: npm run typecheck
 
-      - name: Typecheck
-        run: npm run typecheck
+      - run: npm run lint
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Build
-        run: npm run build
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions CI pipeline to check type definitions, lint, and build

## Testing
- `npm run typecheck` (fails: Cannot find module '@supabase/supabase-js')
- `npm run lint`
- `npm run build` (fails: Cannot find module '@supabase/supabase-js')

------
https://chatgpt.com/codex/tasks/task_e_68a3d4916fa88327b2bcfaf6990da844